### PR TITLE
8 add outpatient dna

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # DES Patient Pathway 0.1.0.9000
 
+* Added Outpatient "did not attend" (DNA) rate to the model
+
 ---
 
 # DES Patient Pathway 0.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # DES Patient Pathway 0.1.0.9000
 
-* Added Outpatient "did not attend" (DNA) rate to the model
+* Added Outpatient "did not attend" (DNA) rate to the model.
+* Removed the probablity distribution (variation) from OP clinic appointment times.  OP clinics are now assumed to be a regular consistent length (adjustable by the user).
 
 ---
 

--- a/R/mod_assumptions.R
+++ b/R/mod_assumptions.R
@@ -19,7 +19,6 @@ mod_assumptions_ui <- function(id) {
           "<ul>
               <li>Is the main queue appearing in the right place?  Is the typical real waiting list post referral and pre OP appointment, or is it post OP appt and pre-admission.</li>
               <li>How to model the queue between OP appt and hospital admission?</li>
-              <li>Appointment non-attendance is not yet modelled.  Attendance is assumed to be 100%.</li>
               <li>The ward is modelled as a shared pre and post-operative ward, but the priority and behaviour of post-op vs. pre-op patients needs to be checked.</li>
               <li>Need to add an additional class of 'priority' patients (eg. cancer) in parallel to the standard patients. Define the queuing behaviour.</li>
               <li>The OP clinic and Theatre schedules are hard-coded as 8hrs/day, 7days/week.  This needs to be user-configurable.</li>

--- a/R/mod_assumptions.R
+++ b/R/mod_assumptions.R
@@ -10,20 +10,37 @@
 mod_assumptions_ui <- function(id) {
   ns <- NS(id)
   tagList(
-    HTML("<p>The code for this project is open-source, and is on <a href='https://github.com/ThomUK/DESPatientPathway' target='_blank'>GitHub.</a></p>"),
+    fluidRow(
+      column(
+        12,
+        h2("Source Code"),
+        HTML("<p>The code for this project is open-source, and is on <a href='https://github.com/ThomUK/DESPatientPathway' target='_blank'>GitHub.</a></p>")
+      )
+    ),
     fluidRow(
       column(
         width = 12,
+        h2("Notes"),
         p("This model is in development.  It is not yet ready to be used for planning.  Some of the issues to be resolved are detailed below."),
         HTML(
           "<ul>
               <li>Is the main queue appearing in the right place?  Is the typical real waiting list post referral and pre OP appointment, or is it post OP appt and pre-admission.</li>
-              <li>How to model the queue between OP appt and hospital admission?</li>
+              <li>How to visualise the queue between OP appt and hospital admission?</li>
               <li>The ward is modelled as a shared pre and post-operative ward, but the priority and behaviour of post-op vs. pre-op patients needs to be checked.</li>
               <li>Need to add an additional class of 'priority' patients (eg. cancer) in parallel to the standard patients. Define the queuing behaviour.</li>
               <li>The OP clinic and Theatre schedules are hard-coded as 8hrs/day, 7days/week.  This needs to be user-configurable.</li>
             </ul>"
         )
+      )
+    ),
+    fluidRow(
+      column(
+        12,
+        h2("Assumptions"),
+        h3("Probability distributions"),
+        p("Exponential distributions are used to model: Patient arrivals (referral times), ward bed length of stay, and theatre length of procedure."),
+        p("In the case of ward and theatre length of stay, this is for simplicity.  A log-normal or similar distribution may fit better, but would require tuning of 2 parameters to fit."),
+        p("There is no probability distribution modelled for OP clinic lengths.  These are assumed to be fixed and regular timings.")
       )
     ),
   )

--- a/R/mod_simulation.R
+++ b/R/mod_simulation.R
@@ -46,6 +46,7 @@ mod_simulation_ui <- function(id) {
           style = "border: 2px solid #ddd; border-radius: 5px; padding: 10px;",
           sliderInput(NS(id, "numPatBacklogSize"), "Number of existing patients in the OP clinic backlog", value = 500, min = 0, max = 5000),
           sliderInput(NS(id, "numPatReferralRate"), "Number of new patient referrals (monthly)", value = 100, min = 0, max = 1000),
+          sliderInput(NS(id, "numOPDNA"), "OP DNA rate (%)", value = 10, min = 0, max = 100),
           sliderInput(NS(id, "numOPOutcomeFup"), "OP outcome: Book followup (%)", value = 25, min = 0, max = 100),
           sliderInput(NS(id, "numOPOutcomeAdmit"), "OP outcome: Admit (%)", value = 10, min = 0, max = 100),
           uiOutput(NS(id, "OPOutcomeDischarge")), # a shinyjs output
@@ -115,6 +116,7 @@ mod_simulation_server <- function(id) {
         forecast_length = input$numForecastLength,
         pat_referral_rate = input$numPatReferralRate,
         pat_backlog_size = input$numPatBacklogSize,
+        op_dna_rate = input$numOPDNA,
         op_admit_rate = input$numOPOutcomeAdmit,
         op_fup_rate = input$numOPOutcomeFup,
         op_clinic_length = input$numOpClinicLength,

--- a/R/mod_simulation.R
+++ b/R/mod_simulation.R
@@ -129,48 +129,72 @@ mod_simulation_server <- function(id) {
 
     # pathway diagram
     output$pathwayDiagram <- DiagrammeR::renderGrViz(DiagrammeR::grViz(
-      "
+      '
       digraph {
 
         # graph attributes
         graph [layout = dot,
                 rankdir = LR,
                 fontname = Arial,
-                label = 'Patient Pathway',
-                labelloc = t]
+                label = "Patient Pathway",
+                labelloc = t,
+                ordering = out]
 
-        # node attributes
-        node [shape = box,
+        # circle nodes
+        node [shape = circle,
               color = black,
               style = filled,
               fillcolor = White;
+              width = 1.2]
+              A;F;
+
+        # rectangle nodes
+        node [shape = box,
+              color = black,
+              style = filled,
+              fillcolor = Linen,
               height = 0.8,
-              width = 1.5]
+              width = 1.5
+              ]
+              B;C;D;E;
+
+        # nodes for comments (easier to place than edge comments)
+        node [  shape = plain
+                style = ""]
+                c1;c2
 
         # edge attributes
-        edge [color = black]
+        edge [  color = black,
+                minlen = 2]
 
         # node statements
-        A [label = 'Patient \n Referral', shape = circle, width = 1.2];
-        B [label = 'Outpatient \n Appointment', fillcolor = Linen];
-        C [label = 'Pre-Op Bed', fillcolor = Linen];
-        D [label = 'Operating \n Theatre', fillcolor = Linen];
-        E [label = 'Post-Op Bed', fillcolor = Linen];
-        F [label = 'Discharge \n Home', shape = circle, width = 1.2];
-
+        A [label = "Patient \n Referral"];
+        B [label = "Outpatient \n Appointment"];
+        C [label = "Pre-Op Bed"];
+        D [label = "Operating \n Theatre"];
+        E [label = "Post-Op Bed"];
+        F [label = "Discharge \n Home"];
+        c1 [label = "Followup \n arranged"];
+        c2 [label = "DNA \n (clinic slot \nwasted)"];
 
         # edge statements
-
         A->B;
-        B->C;
-        B->B [dir=back, label = 'Followup \n arranged'];
+        B:e->C;
+        {
+            rank=same
+            B:ne->c2:e;
+            c2:w->B:nw;
+            B:se->c1:e;
+            c1:w->B:sw;
+
+        }
+        B:e->F;
         C->D;
         D->E;
         E->F;
-        B->F;
 
       }
-      "
+      '
     ))
 
     observeEvent(input$updateButton, {

--- a/R/mod_simulation.R
+++ b/R/mod_simulation.R
@@ -11,7 +11,8 @@ mod_simulation_ui <- function(id) {
   ns <- NS(id)
   tagList(
     shinyjs::useShinyjs(),
-    p("This is a 'Discrete Event Simulation' of the flow of patients through a typical acute trust hopsital service.  Patients are referred in to be seen at an outpatient (OP) clinic.  The clinic takes a decision to admit to waiting list, followup with another clinic appointment later, or discharge completely.  If admitted the patient visits a pre-operative ward, the operating theatre, and finally a post-operative ward before being discharged home."),
+    p("This is a 'Discrete Event Simulation' of the flow of patients through a typical acute trust hopsital service."),
+    p("Patients are referred in to be seen at an outpatient (OP) clinic.  The patients either attend, or do not attend (DNA).  DNAs are re-booked and these patients re-join the clinic waiting list.  Patients that attend the clinic are either admitted to the treatment waiting list, re-booked for a followup appointment, or are discharged completely.  If admitted the patient visits a pre-operative bed, the operating theatre, then a post-operative bed before being discharged home.  The pre and post-operative beds are a shared resource on the same ward."),
     p("This model is in development.  It is not yet ready to be used for planning.  See the 'Notes & Assumptions' tab for more details."),
     fluidRow(
       column(

--- a/R/run_sim.R
+++ b/R/run_sim.R
@@ -61,7 +61,7 @@ run_sim <- function(model_config) {
     # the dna consumes the same clinic resource as an attendance
     log_("OP: DNA") |>
     set_attribute("OP appt DNA", 1) |>
-    timeout(function() rnorm(1, mean = mc$op_clinic_length, sd = 6)) |>
+    timeout(mc$op_clinic_length) |>
     release("OP Clinic", 1) |>
     rollback("op_clinic") # rollback to tagged resource
 
@@ -115,7 +115,7 @@ run_sim <- function(model_config) {
     # if no DNA, continue with the OP appointment
     log_("OP: Attended") |>
     set_attribute("OP appt attended", 1) |>
-    timeout(function() rnorm(1, mean = mc$op_clinic_length, sd = 6)) |>
+    timeout(mc$op_clinic_length) |>
     release("OP Clinic", 1) |>
 
     # branch into admission and discharge

--- a/R/run_sim.R
+++ b/R/run_sim.R
@@ -13,7 +13,8 @@ run_sim <- function(model_config) {
   # Time unit  = minutes
   env <- simmer("pathway")
 
-  # create the distribution functions
+  #### create the distribution functions ####
+  ## continuous distributions ##
   # patient arrivals
   rate <- mc$pat_referral_rate * 12 / 365 / 24 / 60 # monthly -> annual, then calculate patients per minute
   dist_patient_arrival <- function() rexp(1, rate)
@@ -31,6 +32,11 @@ run_sim <- function(model_config) {
 
   dist_post_op_ward_los <- function() rexp(1, 1 / (60 * 24 * mc$post_op_los)) # 60x24 = days
   # dist_post_op_ward_los()
+
+  ## discrete distributions ##
+  # OP did not attend (DNA) rate. 0 = attended, 1 = did not attend
+  dist_op_dna <- function() sample(0:1, 1, FALSE, c(100 - mc$op_dna_rate, mc$op_dna_rate))
+  dist_op_dna()
 
   # OP outcoming result. 1 = admit to wl, 2 = OP followup, 3 = discharged
   op_disch_rate <- (100 - mc$op_admit_rate - mc$op_fup_rate)


### PR DESCRIPTION
closes issue #8 
Adds outpatient non-attendance.
Removes the probability distribution from OP clinic appointment lengths, which are now assumed to be a standard length (configurable in the UI).  